### PR TITLE
Fix command reference in `MakeMerkle.s.sol` script

### DIFF
--- a/script/MakeMerkle.s.sol
+++ b/script/MakeMerkle.s.sol
@@ -10,7 +10,7 @@ import {ScriptHelper} from "murky/script/common/ScriptHelper.sol";
 // Merkle proof generator script
 // To use:
 // 1. Run `forge script script/GenerateInput.s.sol` to generate the input file
-// 2. Run `forge script script/Merkle.s.sol`
+// 2. Run `forge script script/MakeMerkle.s.sol`
 // 3. The output file will be generated in /script/target/output.json
 
 /**


### PR DESCRIPTION
From lines 10-14, instructions are provided for generating Merkle proofs by running various commands. But on line 13, a filename is being mistaken as: `forge script script/Merkle.s.sol`.

The correct commands are indeed mentioned in the README file, but it's still better to keep the comments accurate. That's why I have corrected it to `forge script script/MakeMerkle.s.sol`.

Thanks!